### PR TITLE
Provide proper namespaces

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -59,7 +59,7 @@ class Configurator
         $configuredCache = $this->cache->configureCache();
         $configuredDriver = $this->mapping->configureDriver($configuredCache);
 
-        foreach ($this->configuration->get('namespaces') as $namespace => $path) {
+        foreach ($this->configuration->get('namespaces') as $namespace) {
             $this->driverChain->addDriver($configuredDriver->getMetadataDriverImpl(), $namespace);
         }
 

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -43,7 +43,7 @@ class EntityManager
     }
 
     /**
-     * @return EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public static function instance()
     {


### PR DESCRIPTION
It looped over the array, and used only the keys, while the namespaces is a plain array.